### PR TITLE
Fix nil reference for the case of empty error

### DIFF
--- a/lib/debug_exceptions_json/rspec/formatter.rb
+++ b/lib/debug_exceptions_json/rspec/formatter.rb
@@ -38,7 +38,7 @@ class DebugExceptionsJson
               e = {}
             end
 
-            if e['exception_class'] && e['message'] && e['backtrace']
+            if e && e['exception_class'] && e['message'] && e['backtrace']
               formatted << error_to_dump_message(e)
             end
           end


### PR DESCRIPTION
In some cases (not sure), formatter for rspec3 crashes with following backtrace and I couldn't see real failure messages by running rspec. I couldn't write proper test cases for this right now, but I want to commit this to see error messages.

```
/Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/debug_exceptions_json-0.2.5/lib/debug_exceptions_json/rspec/formatter.rb:41:in `block in dump_failures_3': undefined method `[]' for nil:NilClass (NoMethodError)
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/debug_exceptions_json-0.2.5/lib/debug_exceptions_json/rspec/formatter.rb:30:in `each'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/debug_exceptions_json-0.2.5/lib/debug_exceptions_json/rspec/formatter.rb:30:in `each_with_index'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/debug_exceptions_json-0.2.5/lib/debug_exceptions_json/rspec/formatter.rb:30:in `dump_failures_3'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/debug_exceptions_json-0.2.5/lib/debug_exceptions_json/rspec/formatter.rb:16:in `dump_failures'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:184:in `block in notify'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:183:in `each'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:183:in `notify'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:155:in `block in finish'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:170:in `close_after'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:151:in `finish'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:79:in `report'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:113:in `run_specs'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:89:in `run'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:73:in `run'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:41:in `invoke'
        from /Users/takashi-kokubun/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.1/exe/rspec:4:in `<top (required)>'
        from /Users/takashi-kokubun/.rbenv/versions/2.2/bin/rspec:23:in `load'
        from /Users/takashi-kokubun/.rbenv/versions/2.2/bin/rspec:23:in `<main>'
```
